### PR TITLE
add a new query that takes advantage of the finite input space

### DIFF
--- a/src/Data/TotalMap.hs
+++ b/src/Data/TotalMap.hs
@@ -12,7 +12,7 @@
 -- a default value. Has Applicative and Monad instances (unlike "Data.Map").
 ----------------------------------------------------------------------
 
-module Data.TotalMap (TMap,fromPartial,(!),tabulate,trim,intersectionPartialWith) where
+module Data.TotalMap (TMap,fromPartial,(!),tabulate,trim,intersectionPartialWith,codomain) where
 
 import Data.Monoid (Monoid(..),(<>))
 import Control.Applicative (Applicative(..),liftA2,(<$>))
@@ -62,6 +62,10 @@ intersectionPartialWith f (TMap ad am) bm =
    M.intersectionWith f am bm
    `M.union`
    fmap (f ad) bm
+
+-- | Witness the finiteness of the support concretely by giving its image.
+codomain :: Ord v => TMap k v -> Set v
+codomain (TMap dflt m) = S.fromList (dflt:M.elems m)
 
 {--------------------------------------------------------------------
     Instances


### PR DESCRIPTION
I want to do some `TotalMap` manipulations, then check whether all values meet some criteria. So ultimately I wish for a function with a type like this:

    all :: (v -> Bool) -> TMap k v -> Bool

However, compared to the other functions in the package, this one is hopelessly specific. I've done my best to work out what the "general" form of this operation is; after some thought, I concluded that one might want something like this as the more general form:

    codomain :: Ord v => TMap k v -> Set v

This has an extra `Ord` constraint compared to `all`. For my needs this is fine; though I would be curious whether there was another operation that doesn't require it.